### PR TITLE
fix: exception type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,14 @@ on:
 
 jobs:
   test:
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       
       - name: Install Flutter
-        uses: subosito/flutter-action@v1.3.2
+        uses: subosito/flutter-action@v1.4.0
 
       - name: Run Flutter tests
         run: |

--- a/lib/src/generic_future_button.dart
+++ b/lib/src/generic_future_button.dart
@@ -266,7 +266,7 @@ abstract class GenericFutureButtonState<T extends GenericFutureButtonWidget>
       _state = FutureButtonState.progress;
     });
 
-    Exception error;
+    dynamic error;
     try {
       await widget.onPressed();
     } catch (e) {


### PR DESCRIPTION
Fixed an error where thrown errors (e.g. `NoSuchMethodError`) would throw when assigned to a variable `error` with type `Exception`